### PR TITLE
Omar test1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-<<<<<<< HEAD
         "@types/chromedriver": "^81.0.5",
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
         "@types/mongodb-memory-server": "^2.3.0",
         "@types/semver": "^7.7.0",
         "axios": "^1.7.7",
@@ -66,10 +63,7 @@
         "@types/swagger-ui-express": "^4.1.6",
         "@types/uuid": "^10.0.0",
         "chai": "^4.3.10",
-<<<<<<< HEAD
         "chromedriver": "^136.0.0",
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
         "jest": "^29.7.0",
         "jest-cucumber": "^4.5.0",
         "nodemon": "^3.1.7",
@@ -1648,10 +1642,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@bazel/runfiles/-/runfiles-6.3.1.tgz",
       "integrity": "sha512-1uLNT5NZsUVIGS4syuHwTzZ8HycMPyr6POA3FCE4GbMtc4rhoJk8aZKtNIRthJYfL+iioppi+rTfH3olMPr9nA==",
-<<<<<<< HEAD
       "dev": true,
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
       "license": "Apache-2.0"
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -3604,7 +3595,6 @@
         "node": ">=14"
       }
     },
-<<<<<<< HEAD
     "node_modules/@testim/chrome-version": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.4.tgz",
@@ -3619,8 +3609,6 @@
       "dev": true,
       "license": "MIT"
     },
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -3735,7 +3723,6 @@
       "dev": true,
       "license": "MIT"
     },
-<<<<<<< HEAD
     "node_modules/@types/chromedriver": {
       "version": "81.0.5",
       "resolved": "https://registry.npmjs.org/@types/chromedriver/-/chromedriver-81.0.5.tgz",
@@ -3745,8 +3732,6 @@
         "@types/node": "*"
       }
     },
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -4021,7 +4006,6 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true
     },
-<<<<<<< HEAD
     "node_modules/@types/selenium-webdriver": {
       "version": "4.1.28",
       "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-4.1.28.tgz",
@@ -4033,8 +4017,6 @@
         "@types/ws": "*"
       }
     },
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
     "node_modules/@types/semver": {
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
@@ -4397,7 +4379,6 @@
         "repeat-string": "^1.6.1"
       }
     },
-<<<<<<< HEAD
     "node_modules/ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -4411,8 +4392,6 @@
         "node": ">=4"
       }
     },
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -5182,7 +5161,6 @@
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "license": "MIT"
     },
-<<<<<<< HEAD
     "node_modules/compare-versions": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
@@ -5190,8 +5168,6 @@
       "dev": true,
       "license": "MIT"
     },
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
     "node_modules/component-emitter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
@@ -5385,7 +5361,6 @@
         "node": ">=6"
       }
     },
-<<<<<<< HEAD
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5393,8 +5368,6 @@
       "dev": true,
       "license": "MIT"
     },
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -6002,7 +5975,6 @@
         "node": ">= 8.0.0"
       }
     },
-<<<<<<< HEAD
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -6076,8 +6048,6 @@
         "fd-slicer": "~1.1.0"
       }
     },
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -6130,7 +6100,6 @@
         "bser": "2.1.1"
       }
     },
-<<<<<<< HEAD
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -6141,8 +6110,6 @@
         "pend": "~1.2.0"
       }
     },
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -7043,7 +7010,6 @@
         "node": ">=10"
       }
     },
-<<<<<<< HEAD
     "node_modules/ip-address": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
@@ -7075,8 +7041,6 @@
         "node": ">=8"
       }
     },
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -8239,10 +8203,7 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-<<<<<<< HEAD
       "dev": true,
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
       "license": "(MIT OR GPL-3.0-or-later)",
       "dependencies": {
         "lie": "~3.3.0",
@@ -8255,10 +8216,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-<<<<<<< HEAD
       "dev": true,
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
@@ -8977,7 +8935,6 @@
         "node": ">= 0.6"
       }
     },
-<<<<<<< HEAD
     "node_modules/netmask": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
@@ -8988,8 +8945,6 @@
         "node": ">= 0.4.0"
       }
     },
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
     "node_modules/new-find-package-json": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
@@ -9354,7 +9309,6 @@
         "node": ">=6"
       }
     },
-<<<<<<< HEAD
     "node_modules/pac-proxy-agent": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
@@ -9438,8 +9392,6 @@
         "node": ">= 14"
       }
     },
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -9464,10 +9416,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-<<<<<<< HEAD
       "dev": true,
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parse-json": {
@@ -10293,10 +10242,7 @@
       "version": "4.32.0",
       "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.32.0.tgz",
       "integrity": "sha512-dG48JJnB96Aea1iVaZOKGmd6yT6aemeI1heWI/i8DtfD3pDX7uIlwpDBoGauNhtXAaFaamP+U4hIab8zZkg3Ag==",
-<<<<<<< HEAD
       "dev": true,
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
       "funding": [
         {
           "type": "github",
@@ -10322,10 +10268,7 @@
       "version": "8.18.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
       "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
-<<<<<<< HEAD
       "dev": true,
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -10462,10 +10405,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-<<<<<<< HEAD
       "dev": true,
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
       "license": "MIT"
     },
     "node_modules/setprototypeof": {
@@ -11335,10 +11275,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
       "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
-<<<<<<< HEAD
       "dev": true,
-=======
->>>>>>> a4eafc422ecca49319cc3591d41b99d9417587d4
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/src/tests/integration/chatMessagesIntegration.test.ts
+++ b/src/tests/integration/chatMessagesIntegration.test.ts
@@ -1,0 +1,119 @@
+/**
+ * tests/integration/chatMessagesIntegration.test.ts
+ * -------------------------------------------------
+ * 1) GET /      → 200
+ * 2) POST nuevo → 200
+ * 3) POST dup   → 400
+ */
+
+process.env.DB_URL = 'mongodb://localhost:27017/dummy';
+
+/* ---------- Mock del modelo ChatMessage ---------- */
+type Msg = {
+  messageId:  string;
+  fromUserId: string;
+  toUserId:   string;
+  deliveryId: string;
+  content:    string;
+  _id:        string;
+  createdAt:  Date;
+  toObject(): Msg;
+  save: jest.Mock;            // declaramos save en la interfaz
+};
+
+const store: Msg[] = [
+  {
+    messageId: 'msg1',
+    fromUserId: 'u1',
+    toUserId:   'u2',
+    deliveryId: 'd1',
+    content:    'Hola mundo',
+    _id:        'msg1',
+    createdAt:  new Date(),
+    toObject() { return this; },
+    save: jest.fn(),          // no se usa para el mensaje precargado
+  },
+];
+
+const ChatMessageMock: any = jest.fn().mockImplementation((payload: any) => {
+  const doc: Msg = {
+    ...payload,
+    _id: payload.messageId || 'newId',
+    createdAt: new Date(),
+    toObject() { return this; },
+    save: jest.fn(),          // se define justo aquí
+  };
+
+  // save() resuelve con el propio documento
+  doc.save.mockResolvedValue(doc);
+
+  return doc;
+});
+
+// métodos estáticos
+ChatMessageMock.find = jest.fn().mockImplementation(() => Promise.resolve(store));
+
+ChatMessageMock.findOne = jest.fn().mockImplementation(
+  ({ messageId }: { messageId: string }) =>
+    Promise.resolve(store.find((m) => m.messageId === messageId) || null)
+);
+
+jest.mock('../../models/chatMessage.model', () => ChatMessageMock);
+
+/* ---------- Mock de middlewares ---------- */
+jest.mock('../../middlewares', () => ({
+  authenticate: (_r: any, _s: any, n: any) => n(),
+  authorize: () => (_r: any, _s: any, n: any) => n(),
+  validateRequest: (_r: any, _s: any, n: any) => n(),
+}));
+
+/* ---------- Imports después de mocks ---------- */
+import express from 'express';
+import request from 'supertest';
+import chatRouter from '../../routes/chatMessage.route';
+
+/* Mini‑app con solo las rutas de chat */
+const app = express();
+app.use(express.json());
+app.use('/', chatRouter);
+
+/* ---------- Tests ---------- */
+describe('ChatMessage routes', () => {
+  it('GET / → 200 y lista', async () => {
+    const res = await request(app).get('/');
+    expect(res.status).toBe(200);
+    expect(res.body[0]).toHaveProperty('messageId', 'msg1');
+  });
+
+  it('POST / nuevo → 200 y devuelve mensaje', async () => {
+    const payload = {
+      messageId:  'msg2',
+      fromUserId: 'u1',
+      toUserId:   'u2',
+      deliveryId: 'd1',
+      content:    'Nuevo mensaje',
+      createdAt:  new Date(),
+    };
+
+    const res = await request(app).post('/').send(payload);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('messageId', 'msg2');
+
+    // agrega al store para que el siguiente POST sea duplicado
+    store.push({ ...payload, _id: 'msg2', toObject() { return this; }, save: jest.fn() });
+  });
+
+  it('POST / duplicado → 400', async () => {
+    const duplicate = {
+      messageId:  'msg2', // ya existe
+      fromUserId: 'u1',
+      toUserId:   'u2',
+      deliveryId: 'd1',
+      content:    'Mensaje duplicado',
+      createdAt:  new Date(),
+    };
+
+    const res = await request(app).post('/').send(duplicate);
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/tests/integration/chatMessagesIntegration.test.ts
+++ b/src/tests/integration/chatMessagesIntegration.test.ts
@@ -1,14 +1,6 @@
-/**
- * tests/integration/chatMessagesIntegration.test.ts
- * -------------------------------------------------
- * 1) GET /      → 200
- * 2) POST nuevo → 200
- * 3) POST dup   → 400
- */
 
 process.env.DB_URL = 'mongodb://localhost:27017/dummy';
 
-/* ---------- Mock del modelo ChatMessage ---------- */
 type Msg = {
   messageId:  string;
   fromUserId: string;
@@ -18,7 +10,7 @@ type Msg = {
   _id:        string;
   createdAt:  Date;
   toObject(): Msg;
-  save: jest.Mock;            // declaramos save en la interfaz
+  save: jest.Mock;            
 };
 
 const store: Msg[] = [
@@ -31,7 +23,7 @@ const store: Msg[] = [
     _id:        'msg1',
     createdAt:  new Date(),
     toObject() { return this; },
-    save: jest.fn(),          // no se usa para el mensaje precargado
+    save: jest.fn(),         
   },
 ];
 
@@ -41,16 +33,16 @@ const ChatMessageMock: any = jest.fn().mockImplementation((payload: any) => {
     _id: payload.messageId || 'newId',
     createdAt: new Date(),
     toObject() { return this; },
-    save: jest.fn(),          // se define justo aquí
+    save: jest.fn(),         
   };
 
-  // save() resuelve con el propio documento
+
   doc.save.mockResolvedValue(doc);
 
   return doc;
 });
 
-// métodos estáticos
+
 ChatMessageMock.find = jest.fn().mockImplementation(() => Promise.resolve(store));
 
 ChatMessageMock.findOne = jest.fn().mockImplementation(
@@ -60,24 +52,24 @@ ChatMessageMock.findOne = jest.fn().mockImplementation(
 
 jest.mock('../../models/chatMessage.model', () => ChatMessageMock);
 
-/* ---------- Mock de middlewares ---------- */
+
 jest.mock('../../middlewares', () => ({
   authenticate: (_r: any, _s: any, n: any) => n(),
   authorize: () => (_r: any, _s: any, n: any) => n(),
   validateRequest: (_r: any, _s: any, n: any) => n(),
 }));
 
-/* ---------- Imports después de mocks ---------- */
+
 import express from 'express';
 import request from 'supertest';
 import chatRouter from '../../routes/chatMessage.route';
 
-/* Mini‑app con solo las rutas de chat */
+
 const app = express();
 app.use(express.json());
 app.use('/', chatRouter);
 
-/* ---------- Tests ---------- */
+
 describe('ChatMessage routes', () => {
   it('GET / → 200 y lista', async () => {
     const res = await request(app).get('/');
@@ -99,13 +91,13 @@ describe('ChatMessage routes', () => {
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('messageId', 'msg2');
 
-    // agrega al store para que el siguiente POST sea duplicado
+
     store.push({ ...payload, _id: 'msg2', toObject() { return this; }, save: jest.fn() });
   });
 
   it('POST / duplicado → 400', async () => {
     const duplicate = {
-      messageId:  'msg2', // ya existe
+      messageId:  'msg2', 
       fromUserId: 'u1',
       toUserId:   'u2',
       deliveryId: 'd1',


### PR DESCRIPTION
# Description
Adds an integration‑test suite for the ChatMessage routes (chatMessagesIntegration.test.ts).
The test hits the real router with mocked models/middlewares to cover:

GET / – returns list of messages (200)

POST / – creates a new message (200)

POST / (duplicate) – returns validation error (400)

This increases branch/statement coverage on chatMessage.controller.ts by ≈ 60 p.p. without touching production code.

## Changes

- [ ] Added/Updated functionality
- [ ] Fixed a bug
- [Yes ] Updated tests

## How to Test

<!-- Steps to test the changes -->

1. Run `npm run test`
2. Verify that all tests pass

## Checklist

- [Yes ] Code follows project guidelines
- [ Yes] Tests pass successfully
- [ Yes] No new linting errors
